### PR TITLE
fix(readme): api documentation link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 Enhance your Acode editor experience with customizable UI styles.
 
 > [!WARNING]
-> Version `1.9.0` comes with breaking changes in api for improvements, please check new [documention here](./documention.md).
+> Version `1.9.0` comes with breaking changes in api for improvements, please check new [documention here](https://github.com/overskul/better-ui/blob/main/documention.md).
 
 ## Features ✨
 


### PR DESCRIPTION
The ./documentation.md link was not working from the Acode app, at least for me. Perhaps it could be fixed